### PR TITLE
Bump flyway plugin to v10.21.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,11 @@ libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick-codegen" % Versions.slick,
   "org.postgresql" % "postgresql" % Versions.postgresql,
   "com.github.docker-java" % "docker-java" % Versions.dockerJava,
+
+  // Runtime
+  "org.flywaydb" % "flyway-database-postgresql" % Versions.flyway % Runtime,
 )
-addSbtPlugin("io.github.davidmweber" % "flyway-sbt" % Versions.flywaySbt)
+addSbtPlugin("com.github.sbt" % "flyway-sbt" % Versions.flywaySbt)
 
 publish := codeArtifactPublish.value
 ThisBuild / versionScheme := Some("early-semver")

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,6 +1,7 @@
 object Versions {
   val slick = "3.6.0-pre.77.b845ebab"
-  val postgresql = "42.6.0"
+  val postgresql = "42.7.5"
   val dockerJava = "3.3.4"
-  val flywaySbt = "7.4.0"
+  val flywaySbt = "10.21.0"
+  val flyway = flywaySbt
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,5 +3,5 @@ object Versions {
   val postgresql = "42.7.5"
   val dockerJava = "3.3.4"
   val flywaySbt = "10.21.0"
-  val flyway = flywaySbt
+  val flyway = "10.21.0"
 }

--- a/src/main/scala/com/github/tototoshi/sbt/slick/PluginDBSupport.scala
+++ b/src/main/scala/com/github/tototoshi/sbt/slick/PluginDBSupport.scala
@@ -2,8 +2,8 @@ package com.github.tototoshi.sbt.slick
 
 import sbt.*
 
-import _root_.io.github.davidmweber.FlywayPlugin
 import com.tubitv.PostgresContainer
+import flywaysbt.FlywayPlugin
 
 trait PluginDBSupport {
 
@@ -39,15 +39,15 @@ trait PluginDBSupport {
                 password = dbPass,
                 postgresImage = postgresImage.value,
                 postgresVersion = postgresVersion.value,
-                logger = Keys.streams.value.log
+                logger = Keys.streams.value.log,
               )
             },
-            FlywayPlugin.autoImport.flywayMigrate
+            FlywayPlugin.autoImport.flywayMigrate,
           )
           .value,
         stopDb := {
           PostgresContainer.stop(Keys.streams.value.log)
-        }
+        },
       )
   }
 
@@ -62,5 +62,4 @@ trait PluginDBSupport {
       .dependsOn(startDb)
       .doFinally(stopDb.taskValue)
   }
-
 }


### PR DESCRIPTION
the plugin `flyway-sbt-v10.21.0` introduces `"org.flywaydb" % "flyway-core" % 10.21.0`.
we manually add `"org.flywaydb" % "flyway-database-postgresql" % 10.21.0 % Runtime`